### PR TITLE
Add Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/console": "^10.0",
-        "illuminate/container": "^10.0",
-        "illuminate/contracts": "^10.0",
-        "illuminate/database": "^10.0",
-        "illuminate/queue": "^10.0",
-        "illuminate/support": "^10.0",
+        "illuminate/console": "^9.49.0",
+        "illuminate/container": "^9.49.0",
+        "illuminate/contracts": "^9.49.0",
+        "illuminate/database": "^9.49.0",
+        "illuminate/queue": "^9.49.0",
+        "illuminate/support": "^9.49.0",
         "symfony/finder": "^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "laravel/octane": "^1.4",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^7.20",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.0"
     },


### PR DESCRIPTION
## Context

This PR lowers the composer requirements so that we can use Pennant with our Laravel 9 codebase.